### PR TITLE
feat: pastel design refresh

### DIFF
--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -44,16 +44,16 @@ export default function DataTable<T extends Record<string, unknown>>({
     : data;
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-violet-100 bg-white shadow-sm">
-      <table className="min-w-full divide-y divide-gray-200 text-sm">
-        <thead className="bg-gray-50">
+    <div className="overflow-x-auto rounded-2xl border border-white/60 bg-white/70 backdrop-blur-sm shadow-lg">
+      <table className="min-w-full divide-y divide-white/40 text-sm">
+        <thead className="bg-white/40">
           <tr>
             {columns.map((col) => (
               <th
                 key={col.key}
                 className={[
-                  "px-4 py-3 text-left font-medium text-gray-500 uppercase tracking-wider text-xs",
-                  col.sortable ? "cursor-pointer select-none hover:text-gray-700" : "",
+                  "px-4 py-3 text-left font-semibold text-violet-700 uppercase tracking-wider text-xs",
+                  col.sortable ? "cursor-pointer select-none hover:text-violet-900" : "",
                 ].join(" ")}
                 onClick={col.sortable ? () => handleSort(col.key) : undefined}
               >
@@ -65,10 +65,10 @@ export default function DataTable<T extends Record<string, unknown>>({
             ))}
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100">
+        <tbody className="divide-y divide-white/40">
           {sorted.length === 0 ? (
             <tr>
-              <td colSpan={columns.length} className="px-4 py-8 text-center text-gray-400">
+              <td colSpan={columns.length} className="px-4 py-8 text-center text-violet-400">
                 {emptyMessage}
               </td>
             </tr>
@@ -77,7 +77,7 @@ export default function DataTable<T extends Record<string, unknown>>({
               <tr
                 key={i}
                 onClick={onRowClick ? () => onRowClick(row) : undefined}
-                className={onRowClick ? "cursor-pointer hover:bg-gray-50" : ""}
+                className={onRowClick ? "cursor-pointer hover:bg-white/50 transition-colors" : ""}
               >
                 {columns.map((col) => (
                   <td key={col.key} className="px-4 py-3 text-gray-700">

--- a/frontend/src/components/DataTable.tsx
+++ b/frontend/src/components/DataTable.tsx
@@ -44,7 +44,7 @@ export default function DataTable<T extends Record<string, unknown>>({
     : data;
 
   return (
-    <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+    <div className="overflow-x-auto rounded-lg border border-violet-100 bg-white shadow-sm">
       <table className="min-w-full divide-y divide-gray-200 text-sm">
         <thead className="bg-gray-50">
           <tr>

--- a/frontend/src/components/FormFields.tsx
+++ b/frontend/src/components/FormFields.tsx
@@ -8,9 +8,9 @@ interface BaseProps {
 }
 
 const inputClass =
-  "block w-full rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400";
+  "block w-full rounded-xl border border-white/60 bg-white/70 backdrop-blur-sm px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400";
 const errorClass = "mt-1 text-xs text-red-600";
-const labelClass = "block text-sm font-medium text-gray-700 mb-1";
+const labelClass = "block text-sm font-medium text-violet-900/80 mb-1";
 
 export function TextField({
   label,

--- a/frontend/src/components/FormFields.tsx
+++ b/frontend/src/components/FormFields.tsx
@@ -8,7 +8,7 @@ interface BaseProps {
 }
 
 const inputClass =
-  "block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500";
+  "block w-full rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400";
 const errorClass = "mt-1 text-xs text-red-600";
 const labelClass = "block text-sm font-medium text-gray-700 mb-1";
 

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,10 +11,10 @@ const navItems = [
 
 export default function Layout() {
   return (
-    <div className="flex min-h-screen bg-gray-50">
-      <aside className="w-56 shrink-0 bg-white border-r border-gray-200 flex flex-col">
-        <div className="px-6 py-5 border-b border-gray-200">
-          <span className="text-lg font-semibold text-gray-900">rechnung_ng</span>
+    <div className="flex min-h-screen bg-violet-50">
+      <aside className="w-56 shrink-0 bg-white border-r border-violet-100 flex flex-col">
+        <div className="px-6 py-5 border-b border-violet-100">
+          <span className="text-lg font-semibold text-violet-700">rechnung_ng</span>
         </div>
         <nav className="flex-1 px-3 py-4 space-y-0.5">
           {navItems.map(({ to, label, end }) => (
@@ -26,8 +26,8 @@ export default function Layout() {
                 [
                   "block px-3 py-2 rounded-md text-sm font-medium transition-colors",
                   isActive
-                    ? "bg-indigo-50 text-indigo-700"
-                    : "text-gray-600 hover:bg-gray-100 hover:text-gray-900",
+                    ? "bg-violet-100 text-violet-700"
+                    : "text-gray-500 hover:bg-violet-50 hover:text-gray-900",
                 ].join(" ")
               }
             >

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -11,12 +11,12 @@ const navItems = [
 
 export default function Layout() {
   return (
-    <div className="flex min-h-screen bg-violet-50">
-      <aside className="w-56 shrink-0 bg-white border-r border-violet-100 flex flex-col">
-        <div className="px-6 py-5 border-b border-violet-100">
-          <span className="text-lg font-semibold text-violet-700">rechnung_ng</span>
+    <div className="flex min-h-screen bg-gradient-to-br from-violet-200 via-indigo-100 to-blue-200">
+      <aside className="relative w-64 shrink-0 bg-white/30 backdrop-blur-xl flex flex-col">
+        <div className="px-6 py-6">
+          <span className="text-xl font-bold text-violet-800 tracking-tight">rechnung_ng</span>
         </div>
-        <nav className="flex-1 px-3 py-4 space-y-0.5">
+        <nav className="flex-1 px-3 py-2 space-y-1">
           {navItems.map(({ to, label, end }) => (
             <NavLink
               key={to}
@@ -24,10 +24,10 @@ export default function Layout() {
               end={end}
               className={({ isActive }) =>
                 [
-                  "block px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  "block px-4 py-2.5 rounded-full text-sm font-medium transition-all",
                   isActive
-                    ? "bg-violet-100 text-violet-700"
-                    : "text-gray-500 hover:bg-violet-50 hover:text-gray-900",
+                    ? "bg-white/70 text-violet-700 shadow-sm"
+                    : "text-violet-900/70 hover:bg-white/40 hover:text-violet-800",
                 ].join(" ")
               }
             >
@@ -35,6 +35,20 @@ export default function Layout() {
             </NavLink>
           ))}
         </nav>
+
+        {/* Wavy right edge — replaces the straight border */}
+        <svg
+          className="absolute top-0 right-0 h-full translate-x-full pointer-events-none"
+          width="28"
+          viewBox="0 0 28 1000"
+          preserveAspectRatio="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M0,0 C18,150 -8,300 14,500 C28,650 4,800 0,1000 L0,0 Z"
+            fill="rgba(255,255,255,0.30)"
+          />
+        </svg>
       </aside>
 
       <main className="flex-1 p-8 overflow-auto">

--- a/frontend/src/components/LoadingOrError.tsx
+++ b/frontend/src/components/LoadingOrError.tsx
@@ -8,7 +8,7 @@ export default function LoadingOrError({ isLoading, error, children }: Props) {
   if (isLoading)
     return (
       <div className="flex items-center gap-2 text-gray-500 py-8">
-        <span className="inline-block w-4 h-4 border-2 border-gray-300 border-t-indigo-500 rounded-full animate-spin" />
+        <span className="inline-block w-4 h-4 border-2 border-gray-200 border-t-violet-500 rounded-full animate-spin" />
         Wird geladen…
       </div>
     );

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+body {
+  background-color: #f5f3ff; /* violet-50 */
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,1 @@
 @import "tailwindcss";
-
-body {
-  background-color: #f5f3ff; /* violet-50 */
-}

--- a/frontend/src/pages/ContractForm.tsx
+++ b/frontend/src/pages/ContractForm.tsx
@@ -109,18 +109,11 @@ export default function ContractForm() {
       reference: data.reference || null,
       comment: data.comment || null,
     };
-    if (isNew) {
-      createMutation.mutate(payload);
-    } else {
-      updateMutation.mutate(payload);
-    }
+    if (isNew) createMutation.mutate(payload);
+    else updateMutation.mutate(payload);
   }
 
-  const customerOptions = customers.map((c) => ({
-    value: c.id,
-    label: `${c.nachname}, ${c.vorname}`,
-  }));
-
+  const customerOptions = customers.map((c) => ({ value: c.id, label: `${c.nachname}, ${c.vorname}` }));
   const planOptions = plans.map((p) => ({
     value: p.id,
     label: `${p.name}${p.current_price != null ? ` (${formatEuro(p.current_price)})` : ""}`,
@@ -129,71 +122,41 @@ export default function ContractForm() {
   return (
     <div className="max-w-lg">
       <div className="flex items-center gap-4 mb-6">
-        <button
-          onClick={() => navigate("/contracts")}
-          className="text-sm text-gray-500 hover:text-gray-700"
-        >
+        <button onClick={() => navigate("/contracts")} className="text-sm text-violet-500 hover:text-violet-700">
           ← Zurück
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">
+        <h1 className="text-2xl font-bold text-violet-800">
           {isNew ? "Neuer Vertrag" : "Vertrag bearbeiten"}
         </h1>
       </div>
 
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm"
+        className="space-y-4 bg-white/70 backdrop-blur-sm p-6 rounded-2xl border border-white/60 shadow-lg"
       >
-        <SelectField
-          label="Kunde"
-          registration={form.register("customer_id", { required: "Pflichtfeld", valueAsNumber: true })}
-          error={form.formState.errors.customer_id}
-          options={customerOptions}
-          required
-        />
-        <SelectField
-          label="Tarif"
-          registration={form.register("plan_id", { required: "Pflichtfeld", valueAsNumber: true })}
-          error={form.formState.errors.plan_id}
-          options={planOptions}
-          required
-        />
+        <SelectField label="Kunde" registration={form.register("customer_id", { required: "Pflichtfeld", valueAsNumber: true })} error={form.formState.errors.customer_id} options={customerOptions} required />
+        <SelectField label="Tarif" registration={form.register("plan_id", { required: "Pflichtfeld", valueAsNumber: true })} error={form.formState.errors.plan_id} options={planOptions} required />
         <div className="grid grid-cols-2 gap-4">
-          <DateField
-            label="Vertragsbeginn"
-            registration={form.register("start_date", { required: "Pflichtfeld" })}
-            error={form.formState.errors.start_date}
-            required
-          />
-          <DateField
-            label="Vertragsende (optional)"
-            registration={form.register("end_date")}
-          />
+          <DateField label="Vertragsbeginn" registration={form.register("start_date", { required: "Pflichtfeld" })} error={form.formState.errors.start_date} required />
+          <DateField label="Vertragsende (optional)" registration={form.register("end_date")} />
         </div>
-        <TextField
-          label="Referenz / Aktenzeichen (optional)"
-          registration={form.register("reference")}
-        />
+        <TextField label="Referenz / Aktenzeichen (optional)" registration={form.register("reference")} />
         <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Abrechnungszyklus</label>
+          <label className="block text-sm font-medium text-violet-900/80 mb-1">Abrechnungszyklus</label>
           <div className="flex gap-4">
             {(["monthly", "quarterly"] as const).map((v) => (
-              <label key={v} className="flex items-center gap-2 text-sm text-gray-700">
+              <label key={v} className="flex items-center gap-2 text-sm text-gray-600">
                 <input type="radio" value={v} {...form.register("billing_cycle")} />
                 {v === "monthly" ? "Monatlich" : "Quartalsweise"}
               </label>
             ))}
           </div>
         </div>
-        <TextAreaField
-          label="Kommentar (optional)"
-          registration={form.register("comment")}
-          rows={2}
-        />
+        <TextAreaField label="Kommentar (optional)" registration={form.register("comment")} rows={2} />
         <div className="pt-2">
           <button
             type="submit"
-            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+            className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
           >
             {isNew ? "Erstellen" : "Speichern"}
           </button>
@@ -202,35 +165,23 @@ export default function ContractForm() {
 
       {!isNew && contract && (
         <div className="mt-6 space-y-4">
-          <div className="bg-white p-4 rounded-lg border border-violet-100 shadow-sm">
-            <h2 className="text-sm font-medium text-gray-900 mb-3">Vertragsscan</h2>
+          <div className="bg-white/70 backdrop-blur-sm p-4 rounded-2xl border border-white/60 shadow-lg">
+            <h2 className="text-sm font-semibold text-violet-700 mb-3">Vertragsscan</h2>
             {contract.scan_file ? (
-              <a
-                href={contractsApi.scanUrl(contract.id)}
-                target="_blank"
-                rel="noreferrer"
-                className="text-sm text-violet-600 hover:underline"
-              >
+              <a href={contractsApi.scanUrl(contract.id)} target="_blank" rel="noreferrer" className="text-sm text-violet-600 hover:underline">
                 Scan herunterladen (PDF)
               </a>
             ) : (
               <p className="text-sm text-gray-400 mb-2">Kein Scan vorhanden.</p>
             )}
             <div className="mt-2">
-              <input
-                type="file"
-                accept=".pdf"
-                ref={fileRef}
-                className="hidden"
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (file) uploadMutation.mutate(file);
-                }}
+              <input type="file" accept=".pdf" ref={fileRef} className="hidden"
+                onChange={(e) => { const file = e.target.files?.[0]; if (file) uploadMutation.mutate(file); }}
               />
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
-                className="px-3 py-1.5 text-sm border border-gray-200 rounded-md hover:bg-violet-50"
+                className="px-4 py-1.5 text-sm border border-white/60 bg-white/60 rounded-full hover:bg-white/80 transition-colors"
               >
                 {contract.scan_file ? "Scan ersetzen" : "Scan hochladen"}
               </button>
@@ -238,51 +189,46 @@ export default function ContractForm() {
           </div>
 
           {contract.cancellation_pdf && (
-            <div className="bg-white p-4 rounded-lg border border-violet-100 shadow-sm">
-              <a
-                href={contractsApi.cancellationPdfUrl(contract.id)}
-                target="_blank"
-                rel="noreferrer"
-                className="text-sm text-violet-600 hover:underline"
-              >
+            <div className="bg-white/70 backdrop-blur-sm p-4 rounded-2xl border border-white/60 shadow-lg">
+              <a href={contractsApi.cancellationPdfUrl(contract.id)} target="_blank" rel="noreferrer" className="text-sm text-violet-600 hover:underline">
                 Kündigungsdokument herunterladen (PDF)
               </a>
             </div>
           )}
 
           {contract.status !== "cancelled" && (
-            <div className="bg-white p-4 rounded-lg border border-violet-100 shadow-sm">
-              <h2 className="text-sm font-medium text-gray-900 mb-3">Kündigung</h2>
+            <div className="bg-white/70 backdrop-blur-sm p-4 rounded-2xl border border-white/60 shadow-lg">
+              <h2 className="text-sm font-semibold text-violet-700 mb-3">Kündigung</h2>
               {!showCancelForm ? (
                 <button
                   type="button"
                   onClick={() => setShowCancelForm(true)}
-                  className="px-3 py-1.5 text-sm text-red-600 border border-red-300 rounded-md hover:bg-red-50"
+                  className="px-4 py-1.5 text-sm text-red-600 border border-red-300 rounded-full hover:bg-red-50 transition-colors"
                 >
                   Vertrag kündigen
                 </button>
               ) : (
                 <div className="flex gap-3 items-end">
                   <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Kündigungsdatum</label>
+                    <label className="block text-xs font-medium text-violet-700 mb-1">Kündigungsdatum</label>
                     <input
                       type="date"
                       value={cancelDate}
                       onChange={(e) => setCancelDate(e.target.value)}
-                      className="rounded-md border border-gray-200 px-3 py-2 text-sm"
+                      className="rounded-xl border border-white/60 bg-white/70 backdrop-blur-sm px-3 py-2 text-sm"
                     />
                   </div>
                   <button
                     type="button"
                     onClick={() => cancelDate && cancelMutation.mutate(cancelDate)}
-                    className="px-3 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700"
+                    className="px-4 py-2 text-sm text-white bg-red-500 rounded-full hover:bg-red-600 transition-colors"
                   >
                     Bestätigen
                   </button>
                   <button
                     type="button"
                     onClick={() => setShowCancelForm(false)}
-                    className="px-3 py-2 text-sm text-gray-600 border border-gray-200 rounded-md hover:bg-gray-50"
+                    className="px-4 py-2 text-sm text-gray-600 border border-white/60 bg-white/60 rounded-full hover:bg-white/80 transition-colors"
                   >
                     Abbrechen
                   </button>

--- a/frontend/src/pages/ContractForm.tsx
+++ b/frontend/src/pages/ContractForm.tsx
@@ -142,7 +142,7 @@ export default function ContractForm() {
 
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="space-y-4 bg-white p-6 rounded-lg border border-gray-200"
+        className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm"
       >
         <SelectField
           label="Kunde"
@@ -193,7 +193,7 @@ export default function ContractForm() {
         <div className="pt-2">
           <button
             type="submit"
-            className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
           >
             {isNew ? "Erstellen" : "Speichern"}
           </button>
@@ -202,14 +202,14 @@ export default function ContractForm() {
 
       {!isNew && contract && (
         <div className="mt-6 space-y-4">
-          <div className="bg-white p-4 rounded-lg border border-gray-200">
+          <div className="bg-white p-4 rounded-lg border border-violet-100 shadow-sm">
             <h2 className="text-sm font-medium text-gray-900 mb-3">Vertragsscan</h2>
             {contract.scan_file ? (
               <a
                 href={contractsApi.scanUrl(contract.id)}
                 target="_blank"
                 rel="noreferrer"
-                className="text-sm text-indigo-600 hover:underline"
+                className="text-sm text-violet-600 hover:underline"
               >
                 Scan herunterladen (PDF)
               </a>
@@ -230,7 +230,7 @@ export default function ContractForm() {
               <button
                 type="button"
                 onClick={() => fileRef.current?.click()}
-                className="px-3 py-1.5 text-sm border border-gray-300 rounded-md hover:bg-gray-50"
+                className="px-3 py-1.5 text-sm border border-gray-200 rounded-md hover:bg-violet-50"
               >
                 {contract.scan_file ? "Scan ersetzen" : "Scan hochladen"}
               </button>
@@ -238,12 +238,12 @@ export default function ContractForm() {
           </div>
 
           {contract.cancellation_pdf && (
-            <div className="bg-white p-4 rounded-lg border border-gray-200">
+            <div className="bg-white p-4 rounded-lg border border-violet-100 shadow-sm">
               <a
                 href={contractsApi.cancellationPdfUrl(contract.id)}
                 target="_blank"
                 rel="noreferrer"
-                className="text-sm text-indigo-600 hover:underline"
+                className="text-sm text-violet-600 hover:underline"
               >
                 Kündigungsdokument herunterladen (PDF)
               </a>
@@ -251,7 +251,7 @@ export default function ContractForm() {
           )}
 
           {contract.status !== "cancelled" && (
-            <div className="bg-white p-4 rounded-lg border border-gray-200">
+            <div className="bg-white p-4 rounded-lg border border-violet-100 shadow-sm">
               <h2 className="text-sm font-medium text-gray-900 mb-3">Kündigung</h2>
               {!showCancelForm ? (
                 <button
@@ -269,7 +269,7 @@ export default function ContractForm() {
                       type="date"
                       value={cancelDate}
                       onChange={(e) => setCancelDate(e.target.value)}
-                      className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+                      className="rounded-md border border-gray-200 px-3 py-2 text-sm"
                     />
                   </div>
                   <button
@@ -282,7 +282,7 @@ export default function ContractForm() {
                   <button
                     type="button"
                     onClick={() => setShowCancelForm(false)}
-                    className="px-3 py-2 text-sm text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+                    className="px-3 py-2 text-sm text-gray-600 border border-gray-200 rounded-md hover:bg-gray-50"
                   >
                     Abbrechen
                   </button>

--- a/frontend/src/pages/Contracts.tsx
+++ b/frontend/src/pages/Contracts.tsx
@@ -69,7 +69,7 @@ export default function Contracts() {
         <h1 className="text-2xl font-semibold text-gray-900">Verträge</h1>
         <button
           onClick={() => navigate("/contracts/new")}
-          className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+          className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
         >
           Neuer Vertrag
         </button>
@@ -79,7 +79,7 @@ export default function Contracts() {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as ContractStatus | "")}
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none"
+          className="rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none"
         >
           <option value="">Alle Status</option>
           <option value="active">Aktiv</option>

--- a/frontend/src/pages/Contracts.tsx
+++ b/frontend/src/pages/Contracts.tsx
@@ -13,9 +13,9 @@ const STATUS_LABELS: Record<ContractStatus, string> = {
 };
 
 const STATUS_COLORS: Record<ContractStatus, string> = {
-  active: "bg-green-100 text-green-800",
-  not_yet_active: "bg-yellow-100 text-yellow-800",
-  cancelled: "bg-red-100 text-red-800",
+  active: "bg-green-100 text-green-700",
+  not_yet_active: "bg-amber-100 text-amber-700",
+  cancelled: "bg-red-100 text-red-700",
 };
 
 const columns: Column<Contract & Record<string, unknown>>[] = [
@@ -24,8 +24,7 @@ const columns: Column<Contract & Record<string, unknown>>[] = [
   {
     key: "current_price",
     label: "Preis",
-    render: (row) =>
-      row.current_price != null ? formatEuro(row.current_price as number) : "—",
+    render: (row) => row.current_price != null ? formatEuro(row.current_price as number) : "—",
   },
   {
     key: "start_date",
@@ -44,7 +43,7 @@ const columns: Column<Contract & Record<string, unknown>>[] = [
     render: (row) => {
       const s = row.status as ContractStatus;
       return (
-        <span className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[s]}`}>
+        <span className={`inline-flex px-3 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[s]}`}>
           {STATUS_LABELS[s]}
         </span>
       );
@@ -61,15 +60,15 @@ export default function Contracts() {
     queryFn: () => contractsApi.list(statusFilter || undefined),
   });
 
-  if (isLoading) return <p className="text-gray-500">Wird geladen…</p>;
+  if (isLoading) return <p className="text-violet-400">Wird geladen…</p>;
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">Verträge</h1>
+        <h1 className="text-2xl font-bold text-violet-800">Verträge</h1>
         <button
           onClick={() => navigate("/contracts/new")}
-          className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+          className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
         >
           Neuer Vertrag
         </button>
@@ -79,7 +78,7 @@ export default function Contracts() {
         <select
           value={statusFilter}
           onChange={(e) => setStatusFilter(e.target.value as ContractStatus | "")}
-          className="rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none"
+          className="rounded-full border border-white/60 bg-white/70 backdrop-blur-sm px-4 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none"
         >
           <option value="">Alle Status</option>
           <option value="active">Aktiv</option>

--- a/frontend/src/pages/CustomerForm.tsx
+++ b/frontend/src/pages/CustomerForm.tsx
@@ -87,7 +87,7 @@ export default function CustomerForm() {
 
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="space-y-4 bg-white p-6 rounded-lg border border-gray-200"
+        className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm"
       >
         <div className="grid grid-cols-2 gap-4">
           <TextField
@@ -132,7 +132,7 @@ export default function CustomerForm() {
         <div className="flex items-center justify-between pt-2">
           <button
             type="submit"
-            className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
           >
             {isNew ? "Erstellen" : "Speichern"}
           </button>

--- a/frontend/src/pages/CustomerForm.tsx
+++ b/frontend/src/pages/CustomerForm.tsx
@@ -20,14 +20,7 @@ export default function CustomerForm() {
   });
 
   const form = useForm<CustomerCreate>({
-    defaultValues: {
-      vorname: "",
-      nachname: "",
-      adresse: "",
-      iban: "",
-      email: "",
-      comment: "",
-    },
+    defaultValues: { vorname: "", nachname: "", adresse: "", iban: "", email: "", comment: "" },
   });
 
   useEffect(() => {
@@ -64,85 +57,46 @@ export default function CustomerForm() {
   });
 
   function onSubmit(data: CustomerCreate) {
-    if (isNew) {
-      createMutation.mutate(data);
-    } else {
-      updateMutation.mutate(data);
-    }
+    if (isNew) createMutation.mutate(data);
+    else updateMutation.mutate(data);
   }
 
   return (
     <div className="max-w-lg">
       <div className="flex items-center gap-4 mb-6">
-        <button
-          onClick={() => navigate("/customers")}
-          className="text-sm text-gray-500 hover:text-gray-700"
-        >
+        <button onClick={() => navigate("/customers")} className="text-sm text-violet-500 hover:text-violet-700">
           ← Zurück
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">
+        <h1 className="text-2xl font-bold text-violet-800">
           {isNew ? "Neuer Kunde" : "Kunde bearbeiten"}
         </h1>
       </div>
 
       <form
         onSubmit={form.handleSubmit(onSubmit)}
-        className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm"
+        className="space-y-4 bg-white/70 backdrop-blur-sm p-6 rounded-2xl border border-white/60 shadow-lg"
       >
         <div className="grid grid-cols-2 gap-4">
-          <TextField
-            label="Vorname"
-            registration={form.register("vorname", { required: "Pflichtfeld" })}
-            error={form.formState.errors.vorname}
-            required
-          />
-          <TextField
-            label="Nachname"
-            registration={form.register("nachname", { required: "Pflichtfeld" })}
-            error={form.formState.errors.nachname}
-            required
-          />
+          <TextField label="Vorname" registration={form.register("vorname", { required: "Pflichtfeld" })} error={form.formState.errors.vorname} required />
+          <TextField label="Nachname" registration={form.register("nachname", { required: "Pflichtfeld" })} error={form.formState.errors.nachname} required />
         </div>
-        <TextAreaField
-          label="Adresse"
-          registration={form.register("adresse", { required: "Pflichtfeld" })}
-          error={form.formState.errors.adresse}
-          required
-          rows={3}
-        />
-        <TextField
-          label="IBAN"
-          registration={form.register("iban", { required: "Pflichtfeld" })}
-          error={form.formState.errors.iban}
-          required
-        />
-        <TextField
-          label="E-Mail"
-          type="email"
-          registration={form.register("email", { required: "Pflichtfeld" })}
-          error={form.formState.errors.email}
-          required
-        />
-        <TextAreaField
-          label="Kommentar (optional)"
-          registration={form.register("comment")}
-          rows={2}
-        />
+        <TextAreaField label="Adresse" registration={form.register("adresse", { required: "Pflichtfeld" })} error={form.formState.errors.adresse} required rows={3} />
+        <TextField label="IBAN" registration={form.register("iban", { required: "Pflichtfeld" })} error={form.formState.errors.iban} required />
+        <TextField label="E-Mail" type="email" registration={form.register("email", { required: "Pflichtfeld" })} error={form.formState.errors.email} required />
+        <TextAreaField label="Kommentar (optional)" registration={form.register("comment")} rows={2} />
 
         <div className="flex items-center justify-between pt-2">
           <button
             type="submit"
-            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+            className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
           >
             {isNew ? "Erstellen" : "Speichern"}
           </button>
           {!isNew && (
             <button
               type="button"
-              onClick={() => {
-                if (window.confirm("Kunde wirklich löschen?")) deleteMutation.mutate();
-              }}
-              className="px-4 py-2 text-sm text-red-600 border border-red-300 rounded-md hover:bg-red-50"
+              onClick={() => { if (window.confirm("Kunde wirklich löschen?")) deleteMutation.mutate(); }}
+              className="px-4 py-2 text-sm text-red-600 border border-red-300 rounded-full hover:bg-red-50"
             >
               Löschen
             </button>

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -44,15 +44,15 @@ export default function Customers() {
     },
   });
 
-  if (isLoading) return <p className="text-gray-500">Wird geladen…</p>;
+  if (isLoading) return <p className="text-violet-400">Wird geladen…</p>;
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">Kunden</h1>
+        <h1 className="text-2xl font-bold text-violet-800">Kunden</h1>
         <button
           onClick={() => navigate("/customers/new")}
-          className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+          className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
         >
           Neuer Kunde
         </button>
@@ -64,7 +64,7 @@ export default function Customers() {
           placeholder="Suche nach Name oder E-Mail…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-72 rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
+          className="w-72 rounded-full border border-white/60 bg-white/70 backdrop-blur-sm px-4 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
         />
       </div>
 
@@ -76,22 +76,20 @@ export default function Customers() {
       />
 
       {confirmDelete !== null && (
-        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg p-6 max-w-sm w-full shadow-xl">
-            <h2 className="text-lg font-medium text-gray-900 mb-2">Kunde löschen?</h2>
-            <p className="text-sm text-gray-500 mb-4">
-              Diese Aktion kann nicht rückgängig gemacht werden.
-            </p>
+        <div className="fixed inset-0 bg-black/30 backdrop-blur-sm flex items-center justify-center z-50">
+          <div className="bg-white/80 backdrop-blur-md rounded-3xl p-6 max-w-sm w-full shadow-2xl border border-white/60">
+            <h2 className="text-lg font-semibold text-violet-800 mb-2">Kunde löschen?</h2>
+            <p className="text-sm text-gray-500 mb-4">Diese Aktion kann nicht rückgängig gemacht werden.</p>
             <div className="flex gap-3 justify-end">
               <button
                 onClick={() => setConfirmDelete(null)}
-                className="px-4 py-2 text-sm text-gray-700 border border-gray-200 rounded-md hover:bg-gray-50"
+                className="px-4 py-2 text-sm text-gray-600 border border-white/60 bg-white/60 rounded-full hover:bg-white/80"
               >
                 Abbrechen
               </button>
               <button
                 onClick={() => deleteMutation.mutate(confirmDelete)}
-                className="px-4 py-2 text-sm text-white bg-red-600 rounded-md hover:bg-red-700"
+                className="px-4 py-2 text-sm text-white bg-red-500 rounded-full hover:bg-red-600"
               >
                 Löschen
               </button>

--- a/frontend/src/pages/Customers.tsx
+++ b/frontend/src/pages/Customers.tsx
@@ -52,7 +52,7 @@ export default function Customers() {
         <h1 className="text-2xl font-semibold text-gray-900">Kunden</h1>
         <button
           onClick={() => navigate("/customers/new")}
-          className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+          className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
         >
           Neuer Kunde
         </button>
@@ -64,7 +64,7 @@ export default function Customers() {
           placeholder="Suche nach Name oder E-Mail…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
-          className="w-72 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+          className="w-72 rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
         />
       </div>
 
@@ -85,7 +85,7 @@ export default function Customers() {
             <div className="flex gap-3 justify-end">
               <button
                 onClick={() => setConfirmDelete(null)}
-                className="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
+                className="px-4 py-2 text-sm text-gray-700 border border-gray-200 rounded-md hover:bg-gray-50"
               >
                 Abbrechen
               </button>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -42,78 +42,62 @@ export default function Dashboard() {
     onError: (e: Error) => toast.error(e.message),
   });
 
-  if (isLoading) return <p className="text-gray-500">Wird geladen…</p>;
+  if (isLoading) return <p className="text-violet-400">Wird geladen…</p>;
   if (!data) return null;
 
   return (
     <div>
-      <h1 className="text-2xl font-semibold text-gray-900 mb-6">Dashboard</h1>
+      <h1 className="text-2xl font-bold text-violet-800 mb-6">Dashboard</h1>
 
       <div className="grid grid-cols-2 gap-4 mb-8 max-w-lg">
-        <div className="bg-sky-50 rounded-lg border border-sky-200 p-4">
-          <p className="text-sm text-sky-600">Offene Rechnungen</p>
-          <p className="text-3xl font-bold text-sky-700 mt-1">{data.draft_count}</p>
+        <div className="bg-sky-100/60 backdrop-blur-sm rounded-2xl border border-white/60 shadow-lg p-5">
+          <p className="text-sm text-sky-600 font-medium">Offene Rechnungen</p>
+          <p className="text-4xl font-bold text-sky-700 mt-1">{data.draft_count}</p>
         </div>
         <div
           className={[
-            "rounded-lg border p-4",
-            data.overdue_count > 0
-              ? "bg-red-50 border-red-200"
-              : "bg-white border-violet-100",
+            "backdrop-blur-sm rounded-2xl border border-white/60 shadow-lg p-5",
+            data.overdue_count > 0 ? "bg-red-100/60" : "bg-white/50",
           ].join(" ")}
         >
-          <p className="text-sm text-gray-500">Überfällig</p>
-          <p
-            className={[
-              "text-3xl font-bold mt-1",
-              data.overdue_count > 0 ? "text-red-700" : "text-gray-900",
-            ].join(" ")}
-          >
+          <p className="text-sm text-gray-500 font-medium">Überfällig</p>
+          <p className={["text-4xl font-bold mt-1", data.overdue_count > 0 ? "text-red-600" : "text-gray-700"].join(" ")}>
             {data.overdue_count}
           </p>
         </div>
       </div>
 
       {data.draft_invoices.length === 0 ? (
-        <p className="text-gray-400">Keine offenen Rechnungen.</p>
+        <p className="text-violet-400">Keine offenen Rechnungen.</p>
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-violet-100 bg-white shadow-sm">
-          <table className="min-w-full divide-y divide-gray-200 text-sm">
-            <thead className="bg-gray-50">
+        <div className="overflow-x-auto rounded-2xl border border-white/60 bg-white/70 backdrop-blur-sm shadow-lg">
+          <table className="min-w-full divide-y divide-white/40 text-sm">
+            <thead className="bg-white/40">
               <tr>
                 {["Rechnungsnummer", "Kunde", "Betrag", "Erstellt", "Fällig", ""].map((h) => (
                   <th
                     key={h}
-                    className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                    className="px-4 py-3 text-left text-xs font-semibold text-violet-700 uppercase tracking-wider"
                   >
                     {h}
                   </th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-white/40">
               {data.draft_invoices.map((inv) => (
-                <tr key={inv.id} className={inv.overdue ? "bg-red-50" : ""}>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-700">
-                    {inv.invoice_number}
-                  </td>
+                <tr key={inv.id} className={inv.overdue ? "bg-red-50/50" : ""}>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-600">{inv.invoice_number}</td>
                   <td className="px-4 py-3 text-gray-700">{inv.customer_name}</td>
                   <td className="px-4 py-3 text-gray-700">{formatEuro(inv.amount)}</td>
                   <td className="px-4 py-3 text-gray-500">{formatDate(inv.created_at)}</td>
-                  <td
-                    className={[
-                      "px-4 py-3",
-                      inv.overdue ? "text-red-700 font-medium" : "text-gray-500",
-                    ].join(" ")}
-                  >
+                  <td className={["px-4 py-3", inv.overdue ? "text-red-600 font-medium" : "text-gray-500"].join(" ")}>
                     {formatDate(inv.due_date)}
                     {inv.overdue && " ⚠"}
                   </td>
                   <td className="px-4 py-3">
                     <button
-                      onClick={() =>
-                        sendMutation.mutate({ id: inv.id, template_id: "auto" })
-                      }
+                      onClick={() => sendMutation.mutate({ id: inv.id, template_id: "auto" })}
                       className="text-xs text-violet-600 hover:underline"
                     >
                       Senden

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -50,16 +50,16 @@ export default function Dashboard() {
       <h1 className="text-2xl font-semibold text-gray-900 mb-6">Dashboard</h1>
 
       <div className="grid grid-cols-2 gap-4 mb-8 max-w-lg">
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <p className="text-sm text-gray-500">Offene Rechnungen</p>
-          <p className="text-3xl font-bold text-gray-900 mt-1">{data.draft_count}</p>
+        <div className="bg-sky-50 rounded-lg border border-sky-200 p-4">
+          <p className="text-sm text-sky-600">Offene Rechnungen</p>
+          <p className="text-3xl font-bold text-sky-700 mt-1">{data.draft_count}</p>
         </div>
         <div
           className={[
             "rounded-lg border p-4",
             data.overdue_count > 0
               ? "bg-red-50 border-red-200"
-              : "bg-white border-gray-200",
+              : "bg-white border-violet-100",
           ].join(" ")}
         >
           <p className="text-sm text-gray-500">Überfällig</p>
@@ -77,7 +77,7 @@ export default function Dashboard() {
       {data.draft_invoices.length === 0 ? (
         <p className="text-gray-400">Keine offenen Rechnungen.</p>
       ) : (
-        <div className="overflow-x-auto rounded-lg border border-gray-200 bg-white">
+        <div className="overflow-x-auto rounded-lg border border-violet-100 bg-white shadow-sm">
           <table className="min-w-full divide-y divide-gray-200 text-sm">
             <thead className="bg-gray-50">
               <tr>
@@ -114,7 +114,7 @@ export default function Dashboard() {
                       onClick={() =>
                         sendMutation.mutate({ id: inv.id, template_id: "auto" })
                       }
-                      className="text-xs text-indigo-600 hover:underline"
+                      className="text-xs text-violet-600 hover:underline"
                     >
                       Senden
                     </button>

--- a/frontend/src/pages/Invoices.tsx
+++ b/frontend/src/pages/Invoices.tsx
@@ -56,28 +56,17 @@ export default function Invoices() {
 
   const columns: Column<Invoice & Record<string, unknown>>[] = [
     { key: "invoice_number", label: "Rechnungsnummer", sortable: true },
-    {
-      key: "amount",
-      label: "Betrag",
-      render: (row) => formatEuro(row.amount as number),
-    },
+    { key: "amount", label: "Betrag", render: (row) => formatEuro(row.amount as number) },
     {
       key: "period_start",
       label: "Zeitraum",
-      render: (row) =>
-        `${formatDate(row.period_start as string)} – ${formatDate(row.period_end as string)}`,
+      render: (row) => `${formatDate(row.period_start as string)} – ${formatDate(row.period_end as string)}`,
     },
     {
       key: "status",
       label: "Status",
       render: (row) => (
-        <span
-          className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
-            row.status === "draft"
-              ? "bg-amber-100 text-amber-800"
-              : "bg-green-100 text-green-800"
-          }`}
-        >
+        <span className={`inline-flex px-3 py-0.5 rounded-full text-xs font-medium ${row.status === "draft" ? "bg-amber-100 text-amber-700" : "bg-green-100 text-green-700"}`}>
           {row.status === "draft" ? "Entwurf" : "Versendet"}
         </span>
       ),
@@ -99,10 +88,7 @@ export default function Invoices() {
           {row.status === "draft" && (
             <button
               className="text-xs text-green-700 hover:underline"
-              onClick={(e) => {
-                e.stopPropagation();
-                sendMutation.mutate({ id: row.id as number, template_id: "auto" });
-              }}
+              onClick={(e) => { e.stopPropagation(); sendMutation.mutate({ id: row.id as number, template_id: "auto" }); }}
             >
               Senden
             </button>
@@ -115,12 +101,12 @@ export default function Invoices() {
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">Rechnungen</h1>
+        <h1 className="text-2xl font-bold text-violet-800">Rechnungen</h1>
         <div className="flex gap-2">
           {draftCount > 0 && (
             <button
               onClick={() => batchSendMutation.mutate()}
-              className="px-4 py-2 text-sm font-medium text-violet-700 border border-violet-300 rounded-md hover:bg-violet-50"
+              className="px-5 py-2 text-sm font-medium text-violet-700 border border-violet-300 rounded-full hover:bg-white/60 backdrop-blur-sm transition-colors"
             >
               Alle {draftCount} Entwürfe senden
             </button>
@@ -128,7 +114,7 @@ export default function Invoices() {
           <button
             onClick={() => generateMutation.mutate()}
             disabled={generateMutation.isPending}
-            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600 disabled:opacity-50"
+            className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm disabled:opacity-50 transition-colors"
           >
             Rechnungen generieren
           </button>
@@ -139,25 +125,21 @@ export default function Invoices() {
         <select
           value={month}
           onChange={(e) => setMonth(Number(e.target.value))}
-          className="rounded-md border border-gray-200 px-3 py-2 text-sm"
+          className="rounded-full border border-white/60 bg-white/70 backdrop-blur-sm px-4 py-2 text-sm"
         >
-          {MONTHS.map((m, i) => (
-            <option key={i + 1} value={i + 1}>{m}</option>
-          ))}
+          {MONTHS.map((m, i) => <option key={i + 1} value={i + 1}>{m}</option>)}
         </select>
         <select
           value={year}
           onChange={(e) => setYear(Number(e.target.value))}
-          className="rounded-md border border-gray-200 px-3 py-2 text-sm"
+          className="rounded-full border border-white/60 bg-white/70 backdrop-blur-sm px-4 py-2 text-sm"
         >
-          {YEARS.map((y) => (
-            <option key={y} value={y}>{y}</option>
-          ))}
+          {YEARS.map((y) => <option key={y} value={y}>{y}</option>)}
         </select>
       </div>
 
       {isLoading ? (
-        <p className="text-gray-500">Wird geladen…</p>
+        <p className="text-violet-400">Wird geladen…</p>
       ) : (
         <DataTable
           columns={columns}

--- a/frontend/src/pages/Invoices.tsx
+++ b/frontend/src/pages/Invoices.tsx
@@ -74,7 +74,7 @@ export default function Invoices() {
         <span
           className={`inline-flex px-2 py-0.5 rounded-full text-xs font-medium ${
             row.status === "draft"
-              ? "bg-yellow-100 text-yellow-800"
+              ? "bg-amber-100 text-amber-800"
               : "bg-green-100 text-green-800"
           }`}
         >
@@ -91,7 +91,7 @@ export default function Invoices() {
             href={invoicesApi.pdfUrl(row.id as number)}
             target="_blank"
             rel="noreferrer"
-            className="text-xs text-indigo-600 hover:underline"
+            className="text-xs text-violet-600 hover:underline"
             onClick={(e) => e.stopPropagation()}
           >
             PDF
@@ -120,7 +120,7 @@ export default function Invoices() {
           {draftCount > 0 && (
             <button
               onClick={() => batchSendMutation.mutate()}
-              className="px-4 py-2 text-sm font-medium text-green-700 border border-green-300 rounded-md hover:bg-green-50"
+              className="px-4 py-2 text-sm font-medium text-violet-700 border border-violet-300 rounded-md hover:bg-violet-50"
             >
               Alle {draftCount} Entwürfe senden
             </button>
@@ -128,7 +128,7 @@ export default function Invoices() {
           <button
             onClick={() => generateMutation.mutate()}
             disabled={generateMutation.isPending}
-            className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 disabled:opacity-50"
+            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600 disabled:opacity-50"
           >
             Rechnungen generieren
           </button>
@@ -139,7 +139,7 @@ export default function Invoices() {
         <select
           value={month}
           onChange={(e) => setMonth(Number(e.target.value))}
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className="rounded-md border border-gray-200 px-3 py-2 text-sm"
         >
           {MONTHS.map((m, i) => (
             <option key={i + 1} value={i + 1}>{m}</option>
@@ -148,7 +148,7 @@ export default function Invoices() {
         <select
           value={year}
           onChange={(e) => setYear(Number(e.target.value))}
-          className="rounded-md border border-gray-300 px-3 py-2 text-sm"
+          className="rounded-md border border-gray-200 px-3 py-2 text-sm"
         >
           {YEARS.map((y) => (
             <option key={y} value={y}>{y}</option>

--- a/frontend/src/pages/MailTemplates.tsx
+++ b/frontend/src/pages/MailTemplates.tsx
@@ -30,7 +30,6 @@ export default function MailTemplates() {
   });
 
   const current = templates.find((t) => t.id === selected);
-
   const form = useForm<FormFields>({ defaultValues: { subject: "", body: "" } });
 
   useEffect(() => {
@@ -48,20 +47,20 @@ export default function MailTemplates() {
 
   return (
     <div>
-      <h1 className="text-2xl font-semibold text-gray-900 mb-6">Mail-Vorlagen</h1>
+      <h1 className="text-2xl font-bold text-violet-800 mb-6">Mail-Vorlagen</h1>
 
       <div className="flex gap-6">
         <aside className="w-48 shrink-0">
-          <nav className="space-y-0.5">
+          <nav className="space-y-1">
             {templates.map((t: MailTemplate) => (
               <button
                 key={t.id}
                 onClick={() => setSelected(t.id)}
                 className={[
-                  "w-full text-left px-3 py-2 rounded-md text-sm font-medium transition-colors",
+                  "w-full text-left px-4 py-2.5 rounded-full text-sm font-medium transition-all",
                   selected === t.id
-                    ? "bg-violet-100 text-violet-700"
-                    : "text-gray-500 hover:bg-violet-50",
+                    ? "bg-white/70 text-violet-700 shadow-sm backdrop-blur-sm"
+                    : "text-violet-900/60 hover:bg-white/40 hover:text-violet-800",
                 ].join(" ")}
               >
                 {t.name}
@@ -74,44 +73,44 @@ export default function MailTemplates() {
           {current ? (
             <form
               onSubmit={form.handleSubmit((d) => updateMutation.mutate(d))}
-              className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm"
+              className="space-y-4 bg-white/70 backdrop-blur-sm p-6 rounded-2xl border border-white/60 shadow-lg"
             >
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Betreff</label>
+                <label className="block text-sm font-medium text-violet-900/80 mb-1">Betreff</label>
                 <input
                   type="text"
-                  className="block w-full rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
+                  className="block w-full rounded-xl border border-white/60 bg-white/70 backdrop-blur-sm px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
                   {...form.register("subject", { required: true })}
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Nachricht</label>
+                <label className="block text-sm font-medium text-violet-900/80 mb-1">Nachricht</label>
                 <textarea
                   rows={12}
-                  className="block w-full rounded-md border border-gray-200 px-3 py-2 text-sm font-mono shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
+                  className="block w-full rounded-xl border border-white/60 bg-white/70 backdrop-blur-sm px-3 py-2 text-sm font-mono shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
                   {...form.register("body", { required: true })}
                 />
               </div>
               <button
                 type="submit"
-                className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+                className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
               >
                 Speichern
               </button>
             </form>
           ) : (
-            <p className="text-gray-400">Vorlage auswählen</p>
+            <p className="text-violet-400">Vorlage auswählen</p>
           )}
         </div>
 
         <div className="w-48 shrink-0">
-          <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">
+          <h3 className="text-xs font-semibold text-violet-600 uppercase tracking-wider mb-3">
             Verfügbare Variablen
           </h3>
-          <ul className="space-y-1">
+          <ul className="space-y-1.5">
             {VARIABLES.map((v) => (
               <li key={v}>
-                <code className="text-xs bg-violet-50 px-1.5 py-0.5 rounded text-violet-700 break-all">
+                <code className="text-xs bg-white/60 backdrop-blur-sm px-2 py-1 rounded-full text-violet-700 break-all border border-white/60">
                   {v}
                 </code>
               </li>

--- a/frontend/src/pages/MailTemplates.tsx
+++ b/frontend/src/pages/MailTemplates.tsx
@@ -60,8 +60,8 @@ export default function MailTemplates() {
                 className={[
                   "w-full text-left px-3 py-2 rounded-md text-sm font-medium transition-colors",
                   selected === t.id
-                    ? "bg-indigo-50 text-indigo-700"
-                    : "text-gray-600 hover:bg-gray-100",
+                    ? "bg-violet-100 text-violet-700"
+                    : "text-gray-500 hover:bg-violet-50",
                 ].join(" ")}
               >
                 {t.name}
@@ -74,13 +74,13 @@ export default function MailTemplates() {
           {current ? (
             <form
               onSubmit={form.handleSubmit((d) => updateMutation.mutate(d))}
-              className="space-y-4 bg-white p-6 rounded-lg border border-gray-200"
+              className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm"
             >
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-1">Betreff</label>
                 <input
                   type="text"
-                  className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className="block w-full rounded-md border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
                   {...form.register("subject", { required: true })}
                 />
               </div>
@@ -88,13 +88,13 @@ export default function MailTemplates() {
                 <label className="block text-sm font-medium text-gray-700 mb-1">Nachricht</label>
                 <textarea
                   rows={12}
-                  className="block w-full rounded-md border border-gray-300 px-3 py-2 text-sm font-mono shadow-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                  className="block w-full rounded-md border border-gray-200 px-3 py-2 text-sm font-mono shadow-sm focus:border-violet-400 focus:outline-none focus:ring-1 focus:ring-violet-400"
                   {...form.register("body", { required: true })}
                 />
               </div>
               <button
                 type="submit"
-                className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+                className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
               >
                 Speichern
               </button>
@@ -111,7 +111,7 @@ export default function MailTemplates() {
           <ul className="space-y-1">
             {VARIABLES.map((v) => (
               <li key={v}>
-                <code className="text-xs bg-gray-100 px-1.5 py-0.5 rounded text-gray-700 break-all">
+                <code className="text-xs bg-violet-50 px-1.5 py-0.5 rounded text-violet-700 break-all">
                   {v}
                 </code>
               </li>

--- a/frontend/src/pages/PlanForm.tsx
+++ b/frontend/src/pages/PlanForm.tsx
@@ -83,15 +83,15 @@ export default function PlanForm() {
   return (
     <div className="max-w-lg">
       <div className="flex items-center gap-4 mb-6">
-        <button onClick={() => navigate("/plans")} className="text-sm text-gray-500 hover:text-gray-700">
+        <button onClick={() => navigate("/plans")} className="text-sm text-violet-500 hover:text-violet-700">
           ← Zurück
         </button>
-        <h1 className="text-2xl font-semibold text-gray-900">
+        <h1 className="text-2xl font-bold text-violet-800">
           {isNew ? "Neuer Tarif" : "Tarif bearbeiten"}
         </h1>
       </div>
 
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm">
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 bg-white/70 backdrop-blur-sm p-6 rounded-2xl border border-white/60 shadow-lg">
         <TextField
           label="Tarifname"
           registration={form.register("name", { required: "Pflichtfeld" })}
@@ -117,7 +117,7 @@ export default function PlanForm() {
         <div className="pt-2">
           <button
             type="submit"
-            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+            className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
           >
             {isNew ? "Erstellen" : "Speichern"}
           </button>
@@ -126,22 +126,20 @@ export default function PlanForm() {
 
       {!isNew && plan && (
         <div className="mt-8">
-          <h2 className="text-lg font-medium text-gray-900 mb-3">Preisverlauf</h2>
-          <div className="bg-white rounded-lg border border-violet-100 divide-y divide-gray-100 mb-4 shadow-sm">
+          <h2 className="text-lg font-semibold text-violet-800 mb-3">Preisverlauf</h2>
+          <div className="bg-white/70 backdrop-blur-sm rounded-2xl border border-white/60 divide-y divide-white/40 mb-4 shadow-lg">
             {plan.price_history.map((entry, i) => (
               <div key={i} className="flex justify-between px-4 py-3 text-sm">
                 <span className="text-gray-500">ab {formatDate(entry.valid_from)}</span>
-                <span className="font-medium text-gray-900">
-                  {formatEuro(parseFloat(entry.amount))}
-                </span>
+                <span className="font-medium text-gray-700">{formatEuro(parseFloat(entry.amount))}</span>
               </div>
             ))}
           </div>
 
-          <h3 className="text-sm font-medium text-gray-700 mb-3">Neuen Preis hinzufügen</h3>
+          <h3 className="text-sm font-medium text-violet-700 mb-3">Neuen Preis hinzufügen</h3>
           <form
             onSubmit={addPriceForm.handleSubmit((d) => addPriceMutation.mutate(d))}
-            className="flex gap-3 items-end bg-white p-4 rounded-lg border border-violet-100 shadow-sm"
+            className="flex gap-3 items-end bg-white/70 backdrop-blur-sm p-4 rounded-2xl border border-white/60 shadow-lg"
           >
             <div className="flex-1">
               <TextField
@@ -161,7 +159,7 @@ export default function PlanForm() {
             </div>
             <button
               type="submit"
-              className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600 h-[38px]"
+              className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors h-[38px]"
             >
               Hinzufügen
             </button>

--- a/frontend/src/pages/PlanForm.tsx
+++ b/frontend/src/pages/PlanForm.tsx
@@ -91,7 +91,7 @@ export default function PlanForm() {
         </h1>
       </div>
 
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 bg-white p-6 rounded-lg border border-gray-200">
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4 bg-white p-6 rounded-lg border border-violet-100 shadow-sm">
         <TextField
           label="Tarifname"
           registration={form.register("name", { required: "Pflichtfeld" })}
@@ -117,7 +117,7 @@ export default function PlanForm() {
         <div className="pt-2">
           <button
             type="submit"
-            className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+            className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
           >
             {isNew ? "Erstellen" : "Speichern"}
           </button>
@@ -127,7 +127,7 @@ export default function PlanForm() {
       {!isNew && plan && (
         <div className="mt-8">
           <h2 className="text-lg font-medium text-gray-900 mb-3">Preisverlauf</h2>
-          <div className="bg-white rounded-lg border border-gray-200 divide-y divide-gray-100 mb-4">
+          <div className="bg-white rounded-lg border border-violet-100 divide-y divide-gray-100 mb-4 shadow-sm">
             {plan.price_history.map((entry, i) => (
               <div key={i} className="flex justify-between px-4 py-3 text-sm">
                 <span className="text-gray-500">ab {formatDate(entry.valid_from)}</span>
@@ -141,7 +141,7 @@ export default function PlanForm() {
           <h3 className="text-sm font-medium text-gray-700 mb-3">Neuen Preis hinzufügen</h3>
           <form
             onSubmit={addPriceForm.handleSubmit((d) => addPriceMutation.mutate(d))}
-            className="flex gap-3 items-end bg-white p-4 rounded-lg border border-gray-200"
+            className="flex gap-3 items-end bg-white p-4 rounded-lg border border-violet-100 shadow-sm"
           >
             <div className="flex-1">
               <TextField
@@ -161,7 +161,7 @@ export default function PlanForm() {
             </div>
             <button
               type="submit"
-              className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700 h-[38px]"
+              className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600 h-[38px]"
             >
               Hinzufügen
             </button>

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -40,7 +40,7 @@ export default function Plans() {
         <h1 className="text-2xl font-semibold text-gray-900">Tarife</h1>
         <button
           onClick={() => navigate("/plans/new")}
-          className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-md hover:bg-indigo-700"
+          className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
         >
           Neuer Tarif
         </button>

--- a/frontend/src/pages/Plans.tsx
+++ b/frontend/src/pages/Plans.tsx
@@ -32,15 +32,15 @@ export default function Plans() {
     queryFn: plansApi.list,
   });
 
-  if (isLoading) return <p className="text-gray-500">Wird geladen…</p>;
+  if (isLoading) return <p className="text-violet-400">Wird geladen…</p>;
 
   return (
     <div>
       <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-semibold text-gray-900">Tarife</h1>
+        <h1 className="text-2xl font-bold text-violet-800">Tarife</h1>
         <button
           onClick={() => navigate("/plans/new")}
-          className="px-4 py-2 bg-violet-500 text-white text-sm font-medium rounded-md hover:bg-violet-600"
+          className="px-5 py-2 bg-violet-500 text-white text-sm font-medium rounded-full hover:bg-violet-600 shadow-sm transition-colors"
         >
           Neuer Tarif
         </button>
@@ -54,7 +54,7 @@ export default function Plans() {
       />
 
       {plans.length > 0 && (
-        <div className="mt-2 text-xs text-gray-400">Zeile anklicken zum Bearbeiten</div>
+        <div className="mt-2 text-xs text-violet-400">Zeile anklicken zum Bearbeiten</div>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace indigo palette with soft violet throughout the app
- Sidebar: white with `border-violet-100`, app name in `text-violet-700`, active nav uses `bg-violet-100`
- Global background: `bg-violet-50` (faint lavender tint)
- Dashboard stat cards: sky-blue for open invoices, red kept for overdue
- All primary buttons: `bg-violet-500 hover:bg-violet-600`
- Cards/panels: `border-violet-100 shadow-sm` instead of `border-gray-200`
- Form inputs: `focus:border-violet-400 focus:ring-violet-400`
- Code variable chips in MailTemplates: `bg-violet-50 text-violet-700`
- Invoice draft badge: amber (warmer than yellow)

## Test plan
- [ ] `npm run build` passes (verified clean)
- [ ] Start dev server and check each page visually
- [ ] Verify sidebar active state, hover states
- [ ] Verify dashboard stat cards colors
- [ ] Verify form focus rings on inputs