### PR TITLE
feat: build number in sidebar + GitHub Release on deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,16 @@ jobs:
           context: ./backend
           push: true
           tags: ghcr.io/exportimport/rechnung-ng:latest
+          build-args: |
+            BUILD_NUMBER=${{ github.run_number }}
+            BUILD_SHA=${{ github.sha }}
 
   deploy:
     runs-on: ubuntu-latest
     needs: docker
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - name: Deploy to server
         uses: appleboy/ssh-action@v1
@@ -92,3 +97,16 @@ jobs:
             sudo systemctl restart rechnung-ng-backend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: `build-${{ github.run_number }}`,
+              name: `Build #${{ github.run_number }}`,
+              body: `Commit: ${{ github.sha }}\nDeployed automatically after successful CI.`,
+              target_commitish: '${{ github.sha }}',
+            });

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,10 @@
 FROM python:3.12-slim
 
+ARG BUILD_NUMBER=dev
+ARG BUILD_SHA=local
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+ENV BUILD_SHA=${BUILD_SHA}
+
 RUN apt-get update && apt-get install -y \
     libpango-1.0-0 \
     libharfbuzz0b \

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -9,6 +9,8 @@ from pydantic import BaseModel, Field
 load_dotenv(Path(__file__).parent.parent / ".env")
 
 DATA_DIR = Path(__file__).parent.parent / "data"
+BUILD_NUMBER = os.environ.get("BUILD_NUMBER", "dev")
+BUILD_SHA = os.environ.get("BUILD_SHA", "local")
 TEMPLATES_DIR = Path(__file__).parent / "templates"
 UPLOADS_DIR = Path(__file__).parent.parent / "uploads"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
-from app.config import TEMPLATES_DIR
+from app.config import BUILD_NUMBER, BUILD_SHA, TEMPLATES_DIR
 from app.models.contract import ContractStatus
 from app.models.invoice import InvoiceStatus
 
@@ -71,6 +71,8 @@ templates.globals["CONTRACT_STATUS_LABELS"] = {
     ContractStatus.cancelled: "Gekündigt",
 }
 templates.globals["csrf_token"] = ""  # overridden per-request in render()
+templates.globals["BUILD_NUMBER"] = BUILD_NUMBER
+templates.globals["BUILD_SHA"] = BUILD_SHA
 templates.globals["INVOICE_STATUS_LABELS"] = {
     InvoiceStatus.draft: "Entwurf",
     InvoiceStatus.sent: "Versendet",

--- a/backend/app/static/css/style.css
+++ b/backend/app/static/css/style.css
@@ -202,6 +202,17 @@ input, select, textarea, button { font: inherit; }
   color: #5b21b6;
   box-shadow: var(--shadow-sm);
 }
+.sidebar__build {
+  padding: 0.5rem 1rem 0.75rem;
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  border-top: 1px solid var(--color-border);
+  margin-top: 0.5rem;
+}
+.sidebar__build-sha {
+  font-family: monospace;
+  opacity: 0.7;
+}
 
 /* ---------------------------------------------------------
    Page Header

--- a/backend/app/templates/base.html.j2
+++ b/backend/app/templates/base.html.j2
@@ -73,6 +73,10 @@
         </a>
       </li>
     </ul>
+    <div class="sidebar__build">
+      Build #{{ BUILD_NUMBER }}
+      <span class="sidebar__build-sha">{{ BUILD_SHA[:7] }}</span>
+    </div>
   </nav>
 
   <main id="main-content" class="main-content">

--- a/backend/tests/test_build_info.py
+++ b/backend/tests/test_build_info.py
@@ -1,0 +1,9 @@
+"""Build info shown in page footer."""
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_build_info_shown_in_footer(client):
+    r = await client.get("/")
+    assert r.status_code == 200
+    assert "Build #" in r.text


### PR DESCRIPTION
Closes #13

## Summary
- Sidebar footer shows `Build #N abc1234` on every page
- CI bakes `BUILD_NUMBER` (run number) and `BUILD_SHA` (commit SHA) into the Docker image as build args → env vars
- After each successful deploy, a GitHub Release `Build #N` is created automatically with the commit SHA

## How to verify
1. Open the app → check bottom of sidebar for `Build #N`
2. Open GitHub → Releases → confirm matching `Build #N` entry with the same commit SHA

## Test plan
- [x] `test_build_info_shown_in_footer` — confirms `Build #` appears in full-page response
- [x] 206 tests passing, no regressions